### PR TITLE
Add MkDocs documentation scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,8 +39,8 @@ vignettes/*.pdf
 # R Environment Variables
 .Renviron
 
-# pkgdown site
-docs/
+# pkgdown site (use MkDocs instead)
+# docs/
 
 # translation temp files
 po/*~

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,25 @@
+# Eco Trans Early Warning
+
+Welcome to the documentation site for the Eco_Trans_Early_Warning project. This initiative focuses on detecting early warning signals of ecosystem transformations using remote sensing data products and statistical learning techniques.
+
+## Project Goals
+- Integrate multi-source remote sensing rasters (NDVI, soil moisture, drought indices, transition maps, fire history, and static drivers).
+- Derive early warning indicators such as autocorrelation, variance, and vegetation trends to anticipate ecosystem changes.
+- Model warning lead times with Bayesian Additive Regression Trees (BART) and Generalized Additive Models (GAMs).
+- Produce spatial predictions that highlight areas at risk of rapid ecological transitions.
+
+## Repository Highlights
+- **Data management**: Raster inputs reside in the `data/` directory, while processed artifacts and model outputs are stored in `output/`.
+- **Reproducible scripts**: The `scripts/` folder contains modular R scripts for loading data, engineering features, training models, and generating predictions.
+- **End-to-end workflow**: `scripts/full_primary_workflow.R` orchestrates the key analytical steps for reproducibility.
+
+## Getting Started
+1. Review the tutorials in this documentation to understand how to run the workflow end-to-end.
+2. Ensure required R packages (including `terra`, `dbarts`, and `mgcv`) are installed.
+3. Update paths in the scripts to match your local raster data locations.
+4. Execute the primary workflow script or individual stages as needed.
+
+## Further Reading
+- [Early warning signals in ecological systems](https://doi.org/10.1016/j.tree.2015.05.009)
+- [Bayesian Additive Regression Trees](https://projecteuclid.org/journals/annals-of-applied-statistics/volume-4/issue-1/Bayesian-additive-regression-trees/10.1214/09-AOAS285.short)
+

--- a/docs/reference/data-structure.md
+++ b/docs/reference/data-structure.md
@@ -1,0 +1,19 @@
+# Data and Output Structure
+
+Understanding the repository layout makes it easier to locate inputs, intermediate artifacts, and final results.
+
+## `data/`
+Stores raw and preprocessed raster inputs, including NDVI, soil moisture, drought metrics, land-transition labels, historical fire data, and static environmental drivers.
+
+## `output/`
+Holds derived artifacts produced by the workflow, such as cleaned rasters, extracted feature tables, model fits, and prediction maps. Intermediate caches can also be saved here to accelerate repeated analyses.
+
+## `scripts/`
+Contains the R scripts that implement data processing, feature engineering, modeling, and prediction steps. See the [Workflow Overview](../tutorials/workflow-overview.md) tutorial for details on each script.
+
+## Suggested Additions
+Consider adding the following folders as the project grows:
+- `docs/` — houses MkDocs documentation pages (this site).
+- `reports/` — stores rendered notebooks or analytical summaries.
+- `config/` — captures parameter files or environment settings for reproducibility.
+

--- a/docs/tutorials/workflow-overview.md
+++ b/docs/tutorials/workflow-overview.md
@@ -1,0 +1,39 @@
+# Workflow Overview
+
+This tutorial outlines the primary R scripts that drive the Eco_Trans_Early_Warning analysis pipeline. Use it as a reference for running the project end-to-end or focusing on individual processing stages.
+
+## 1. Load and Prepare Rasters
+- **Script**: `scripts/01_load_rasters.R`
+- **Purpose**: Aligns NDVI, soil moisture, drought indices, transition labels, fire history, and static driver rasters. Ensures all inputs share a common projection, resolution, and extent.
+- **Tips**:
+  - Inspect raster metadata before processing to confirm spatial alignment.
+  - Cache intermediate rasters in `output/` to avoid repeated expensive reads.
+
+## 2. Extract Early Warning Signals and Drivers
+- **Script**: `scripts/02_extract_ews_and_drivers.R`
+- **Purpose**: Sources the raster-loading utilities, computes early warning indicators (autocorrelation, variance, NDVI slope), estimates signal emergence, and compiles a pixel-level feature table.
+- **Tips**:
+  - Review helper functions like `detect_ews_year` and `compute_ews` to understand how indicators are derived.
+  - Adjust rolling window parameters to tune sensitivity to transitions.
+
+## 3. Fit Predictive Models
+- **Script**: `scripts/03_fit_bart_model.R`
+- **Purpose**: Trains a Bayesian Additive Regression Trees (BART) model on engineered features to predict lead time before transitions.
+- **Tips**:
+  - Experiment with hyperparameters such as the number of trees to balance accuracy and interpretability.
+  - Evaluate partial dependence plots to interpret driver effects.
+
+## 4. Generate Spatial Predictions
+- **Script**: `scripts/04_predict_lead_time_raster.R`
+- **Purpose**: Projects BART predictions back onto raster space, creating spatial maps of anticipated lead time.
+- **Tips**:
+  - Validate predictions against held-out regions or historical events.
+  - Export GeoTIFF outputs to share with collaborators.
+
+## 5. Run the Full Workflow
+- **Script**: `scripts/full_primary_workflow.R`
+- **Purpose**: Integrates all steps to deliver a reproducible pipeline from raw rasters to prediction maps and evaluation metrics.
+- **Tips**:
+  - Start with a small spatial subset to verify the pipeline before scaling up.
+  - Consider orchestrating the workflow with `targets` or `drake` for large-scale automation.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,12 @@
+site_name: Eco Trans Early Warning
+repo_url: https://github.com/eco-trans/Eco_Trans_Early_Warning
+site_description: Documentation for the Eco_Trans_Early_Warning remote sensing workflow.
+theme:
+  name: material
+nav:
+  - Home: index.md
+  - Tutorials:
+      - Workflow Overview: tutorials/workflow-overview.md
+  - Reference:
+      - Data & Output Structure: reference/data-structure.md
+docs_dir: docs


### PR DESCRIPTION
## Summary
- configure MkDocs with a Material-themed site, repository metadata, and navigation
- add initial documentation pages covering project overview, workflow tutorial, and repository structure
- update `.gitignore` to allow tracking the new MkDocs-based documentation directory

## Testing
- `mkdocs build` *(fails: MkDocs is not available in the execution environment and cannot be installed due to restricted network access)*

------
https://chatgpt.com/codex/tasks/task_e_68d195ee999483318e5ae1183c839067