### PR TITLE
Add documentation deployment workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,44 @@
+name: Build and Deploy Docs
+
+on:
+  push:
+    branches:
+      - main
+  release:
+    types:
+      - published
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install mkdocs-material
+
+      - name: Build documentation
+        run: mkdocs build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          personal_token: ${{ secrets.PERSONAL_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: site
+          keep_files: false
+          force_orphan: true


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build MkDocs documentation on pushes to main and published releases
- install mkdocs-material, compile the site, and deploy the output to the gh-pages branch via peaceiris/actions-gh-pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d198ae030c8331bd54ee22dcf0c1d5