### PR TITLE
Revamp portfolio documentation site

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -1,0 +1,59 @@
+---
+title: About
+---
+
+# About
+
+I am a remote sensing scientist focused on translating satellite observations into timely indicators of ecosystem change. By combining spatial statistics, machine learning, and domain collaboration, I help land managers anticipate critical transitions before they become irreversible.
+
+## Research focus
+
+My work centers on three guiding questions:
+
+1. **How early can satellite signals reveal ecological instability?** I explore lag-1 autocorrelation, variance, vegetation trend, and other early warning metrics to quantify transitions before they manifest on the ground.
+2. **What drivers accelerate or buffer change?** Integrating fire history, drought intensity, topography, and soil context uncovers the mechanisms behind resilience loss.
+3. **How do we convert model output into action?** I prioritize clear communication and reproducible tooling so partners can deploy interventions with confidence.
+
+## Expertise at a glance
+
+<div class="summary-grid">
+  <div class="feature-card">
+    <h3>Geospatial analytics</h3>
+    <p>Processing large raster stacks, deriving pixel-level time series, and building scalable workflows with <code>terra</code> and <code>furrr</code>.</p>
+  </div>
+  <div class="feature-card">
+    <h3>Statistical modeling</h3>
+    <p>Generalized additive models, Bayesian Additive Regression Trees, and ensemble diagnostics for uncertainty-aware decision support.</p>
+  </div>
+  <div class="feature-card">
+    <h3>Collaborative science</h3>
+    <p>Partnering with interdisciplinary teams to design reproducible analyses, release open-source tools, and deliver stakeholder-ready briefings.</p>
+  </div>
+</div>
+
+## Working principles
+
+!!! tip "Human-centered analytics"
+    Field partners and resource managers help shape every workflow decision, from variable selection to visualization, ensuring outputs remain relevant on the ground.
+
+!!! note "Transparent research"
+    Version-controlled pipelines, comprehensive documentation, and open issue tracking keep the science auditable and adaptable.
+
+!!! success "Iterative delivery"
+    Rapid prototypes, short feedback loops, and modular scripts mean insights mature alongside stakeholder needs.
+
+## Highlights
+
+- Designed the **Eco-Trans Early Warning** workflow to capture lead times ahead of forest-to-shrubland transitions.
+- Benchmarked early warning indicators across fire and non-fire pathways, surfacing performance gaps that guide targeted model refinement.
+- Published reproducible scripts and documentation that shorten onboarding time for collaborators and students.
+
+## Connect {#connect}
+
+- GitHub: [@chathu84](https://github.com/chathu84)
+- Repository: [Eco_Trans_Early_Warning](https://github.com/eco-trans/Eco_Trans_Early_Warning)
+- Prefer email? Reach out through your institution’s directory or send a direct message on GitHub to start a conversation.
+
+## Availability
+
+I am open to collaborations that require actionable monitoring of ecosystem health, from rapid assessments to long-term remote sensing observatories. Let’s explore how early warning analytics can support your mission.

--- a/docs/assets/styles/extra.css
+++ b/docs/assets/styles/extra.css
@@ -1,0 +1,148 @@
+:root {
+  --hero-bg: linear-gradient(135deg, rgba(0, 121, 107, 0.12), rgba(128, 222, 234, 0.24));
+  --card-border: 1px solid rgba(0, 0, 0, 0.08);
+  --card-shadow: 0 12px 24px rgba(17, 24, 39, 0.08);
+}
+
+.hero {
+  background: var(--hero-bg);
+  border-radius: 18px;
+  padding: 3.5rem clamp(1.5rem, 4vw, 3rem);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.hero__content {
+  max-width: 780px;
+}
+
+.hero__eyebrow {
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--md-primary-fg-color);
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.hero__lead {
+  font-size: 1.2rem;
+  margin: 1.25rem 0 2rem 0;
+  color: var(--md-default-fg-color--light);
+}
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.feature-grid,
+.project-grid,
+.summary-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.feature-grid {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.feature-card,
+.project-card,
+.timeline,
+.cta-panel {
+  background: var(--md-default-bg-color);
+  border-radius: 14px;
+  border: var(--card-border);
+  box-shadow: var(--card-shadow);
+  padding: 1.5rem clamp(1.25rem, 3vw, 2rem);
+}
+
+.feature-card h3,
+.project-card h3,
+.project-card h2 {
+  margin-top: 0;
+}
+
+.feature-card p,
+.project-card p {
+  color: var(--md-default-fg-color--light);
+}
+
+.project-grid {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.project-card .project-meta {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 1.5rem 0;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.project-card .project-meta li {
+  color: var(--md-default-fg-color--light);
+  font-size: 0.9rem;
+}
+
+.timeline {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.timeline__item {
+  border-left: 3px solid var(--md-primary-fg-color);
+  padding-left: 1rem;
+}
+
+.timeline__item time {
+  display: inline-block;
+  font-weight: 600;
+  color: var(--md-primary-fg-color);
+  margin-bottom: 0.25rem;
+}
+
+.cta-panel {
+  display: grid;
+  gap: 0.75rem;
+  align-items: center;
+  text-align: center;
+}
+
+.cta-panel strong {
+  font-size: 1.15rem;
+}
+
+.cards-inline {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.cards-inline .mini-card {
+  border-radius: 12px;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  background: rgba(128, 222, 234, 0.15);
+  padding: 1rem;
+  text-align: left;
+}
+
+.cards-inline .mini-card strong {
+  display: block;
+  margin-bottom: 0.35rem;
+}
+
+@media screen and (max-width: 600px) {
+  .hero {
+    padding: 2.5rem 1.5rem;
+  }
+
+  .hero__lead {
+    font-size: 1.05rem;
+  }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,25 +1,130 @@
-# Eco Trans Early Warning
+---
+title: Home
+---
 
-Welcome to the documentation site for the Eco_Trans_Early_Warning project. This initiative focuses on detecting early warning signals of ecosystem transformations using remote sensing data products and statistical learning techniques.
+<div class="hero">
+  <div class="hero__content">
+    <p class="hero__eyebrow">Remote sensing & ecosystem resilience</p>
+    <h1>Dr. Nayani Ilangakoon</h1>
+    <p class="hero__lead">
+      I build geospatial analytics that surface early warning signals of ecosystem transformation so land managers can make confident, proactive decisions.
+    </p>
+    <div class="hero__actions">
+      <a class="md-button md-button--primary" href="projects/">Explore projects</a>
+      <a class="md-button" href="about/">Learn more about my work</a>
+      <a class="md-button" href="https://github.com/chathu84" target="_blank" rel="noopener">GitHub portfolio</a>
+    </div>
+  </div>
+</div>
 
-## Project Goals
-- Integrate multi-source remote sensing rasters (NDVI, soil moisture, drought indices, transition maps, fire history, and static drivers).
-- Derive early warning indicators such as autocorrelation, variance, and vegetation trends to anticipate ecosystem changes.
-- Model warning lead times with Bayesian Additive Regression Trees (BART) and Generalized Additive Models (GAMs).
-- Produce spatial predictions that highlight areas at risk of rapid ecological transitions.
+## What I do
 
-## Repository Highlights
-- **Data management**: Raster inputs reside in the `data/` directory, while processed artifacts and model outputs are stored in `output/`.
-- **Reproducible scripts**: The `scripts/` folder contains modular R scripts for loading data, engineering features, training models, and generating predictions.
-- **End-to-end workflow**: `scripts/full_primary_workflow.R` orchestrates the key analytical steps for reproducibility.
+<div class="feature-grid">
+  <div class="feature-card">
+    <h3>Satellite data integration</h3>
+    <p>Design cloud-ready pipelines that blend NDVI, soil moisture, drought, transition history, and fire severity rasters into analysis-ready stacks.</p>
+    <ul>
+      <li>Automated alignment and reprojection</li>
+      <li>Pixel-level time series extraction</li>
+      <li>Quality control and gap filling</li>
+    </ul>
+  </div>
+  <div class="feature-card">
+    <h3>Early warning analytics</h3>
+    <p>Engineer statistical indicators—including autocorrelation, variance, and vegetation trends—that detect emerging ecological instability.</p>
+    <ul>
+      <li>Signal emergence monitoring</li>
+      <li>Fire vs. non-fire stratification</li>
+      <li>Generalized additive and BART modeling</li>
+    </ul>
+  </div>
+  <div class="feature-card">
+    <h3>Decision-ready insights</h3>
+    <p>Translate model outputs into spatial products and reports so partners can prioritize interventions across vulnerable landscapes.</p>
+    <ul>
+      <li>Lead-time mapping</li>
+      <li>Performance dashboards</li>
+      <li>Collaborative workflow design</li>
+    </ul>
+  </div>
+</div>
 
-## Getting Started
-1. Review the tutorials in this documentation to understand how to run the workflow end-to-end.
-2. Ensure required R packages (including `terra`, `dbarts`, and `mgcv`) are installed.
-3. Update paths in the scripts to match your local raster data locations.
-4. Execute the primary workflow script or individual stages as needed.
+## Featured projects
 
-## Further Reading
-- [Early warning signals in ecological systems](https://doi.org/10.1016/j.tree.2015.05.009)
-- [Bayesian Additive Regression Trees](https://projecteuclid.org/journals/annals-of-applied-statistics/volume-4/issue-1/Bayesian-additive-regression-trees/10.1214/09-AOAS285.short)
+<div class="project-grid">
+  <article class="project-card">
+    <h3>Eco-Trans Early Warning</h3>
+    <p>A full-stack workflow that detects early warning signals ahead of forest-to-shrubland transitions using multi-sensor remote sensing data.</p>
+    <ul class="project-meta">
+      <li><strong>Focus:</strong> Ecosystem transition forecasting</li>
+      <li><strong>Stack:</strong> R, terra, dbarts, mgcv</li>
+      <li><strong>Outputs:</strong> Lead-time rasters, performance diagnostics</li>
+    </ul>
+    <a class="md-button md-button--primary" href="projects/eco-trans-early-warning/">View project</a>
+  </article>
+  <article class="project-card">
+    <h3>Fire-response model accuracy</h3>
+    <p>Evaluates how early warning indicators perform under fire-driven transitions, revealing where detection models must adapt.</p>
+    <ul class="project-meta">
+      <li><strong>Focus:</strong> Post-disturbance resilience</li>
+      <li><strong>Stack:</strong> R, mgcv, pROC</li>
+      <li><strong>Outputs:</strong> Stratified ROC curves, AUC summaries</li>
+    </ul>
+    <a class="md-button" href="projects/fire-response-model-accuracy/">Explore insights</a>
+  </article>
+  <article class="project-card">
+    <h3>Lead time prediction suite</h3>
+    <p>Bayesian Additive Regression Trees for quantifying how terrain, climate, and vegetation dynamics shape intervention windows.</p>
+    <ul class="project-meta">
+      <li><strong>Focus:</strong> Actionable warning lead times</li>
+      <li><strong>Stack:</strong> R, dbarts, tidyverse</li>
+      <li><strong>Outputs:</strong> Model fits, predictor importance, forecasts</li>
+    </ul>
+    <a class="md-button" href="projects/lead-time-prediction-suite/">Dive into the workflow</a>
+  </article>
+</div>
 
+## Strategy & impact
+
+<div class="cards-inline">
+  <div class="mini-card">
+    <strong>Bridging science & action</strong>
+    <span>I partner with ecologists and land managers to co-design monitoring frameworks that translate data science into policy-ready insights.</span>
+  </div>
+  <div class="mini-card">
+    <strong>Scalable geospatial engineering</strong>
+    <span>Pipeline automation keeps analyses reproducible across landscapes and fuels rapid iteration on new data products.</span>
+  </div>
+  <div class="mini-card">
+    <strong>Open collaboration</strong>
+    <span>Code, documentation, and reproducible notebooks encourage community reuse and transparency.</span>
+  </div>
+</div>
+
+## Latest highlights
+
+<div class="timeline">
+  <div class="timeline__item">
+    <time>2025</time>
+    <p>Expanded the Eco-Trans workflow with a modular projects hub, highlighting end-to-end processing from raster ingestion through lead-time prediction.</p>
+  </div>
+  <div class="timeline__item">
+    <time>2024</time>
+    <p>Benchmarked early warning metrics across fire and non-fire transitions, exposing thresholds that enhance resilience planning.</p>
+  </div>
+  <div class="timeline__item">
+    <time>2023</time>
+    <p>Integrated Bayesian tree ensembles to quantify transition lead times, guiding prioritization of restoration investments.</p>
+  </div>
+</div>
+
+## Work with me
+
+<div class="cta-panel">
+  <strong>Let’s build proactive ecosystem monitoring together.</strong>
+  <p>From remote sensing data fusion to explainable prediction models, I collaborate on projects that turn satellite signals into actionable foresight.</p>
+  <div class="hero__actions">
+    <a class="md-button md-button--primary" href="projects/">Browse the full project catalog</a>
+    <a class="md-button" href="about/#connect">Get in touch</a>
+  </div>
+</div>

--- a/docs/projects/eco-trans-early-warning.md
+++ b/docs/projects/eco-trans-early-warning.md
@@ -1,0 +1,47 @@
+---
+title: Eco-Trans Early Warning
+---
+
+# Eco-Trans Early Warning
+
+A reproducible workflow for detecting early warning signals of ecosystem transformation in forested landscapes. The project integrates multi-sensor remote sensing products, statistical feature engineering, and advanced modeling to estimate how much lead time managers have before transitions occur.
+
+## Why it matters
+
+- Forest-to-shrubland conversions are accelerating under drought stress, altered fire regimes, and climate change.
+- Reliable early warning signals allow agencies to deploy treatments and restoration crews before resilience thresholds are crossed.
+- Open, well-documented tooling ensures results can be validated, extended, and scaled across regions.
+
+## Workflow architecture
+
+1. **Raster ingestion and harmonization** using [`scripts/01_load_rasters.R`](https://github.com/eco-trans/Eco_Trans_Early_Warning/blob/main/scripts/01_load_rasters.R) ensures NDVI, soil moisture, drought indices, fire history, and static drivers share a common grid.
+2. **Early warning metric extraction** ([`scripts/02_extract_ews_and_drivers.R`](https://github.com/eco-trans/Eco_Trans_Early_Warning/blob/main/scripts/02_extract_ews_and_drivers.R)) computes lag-1 autocorrelation, variance, NDVI slope, and fire frequency for each pixel, then assembles a modeling-ready table.
+3. **Lead-time modeling** with Bayesian Additive Regression Trees in [`scripts/03_fit_bart_model.R`](https://github.com/eco-trans/Eco_Trans_Early_Warning/blob/main/scripts/03_fit_bart_model.R) estimates intervention windows while quantifying variable influence.
+4. **Spatial prediction** ([`scripts/04_predict_lead_time_raster.R`](https://github.com/eco-trans/Eco_Trans_Early_Warning/blob/main/scripts/04_predict_lead_time_raster.R)) projects model outputs back into raster space for decision-ready mapping.
+
+!!! info "Reproducible pipeline"
+    The [`scripts/full_primary_workflow.R`](https://github.com/eco-trans/Eco_Trans_Early_Warning/blob/main/scripts/full_primary_workflow.R) script orchestrates the end-to-end process and serves as the fastest way to reproduce results from raw rasters to evaluation metrics.
+
+## Data sources
+
+- **Vegetation:** Annual NDVI stacks covering two decades of seasonal dynamics.
+- **Hydroclimate:** Soil moisture, drought indices, and precipitation layers describing resource availability.
+- **Disturbance:** Fire history composites capturing frequency and severity prior to transition events.
+- **Static drivers:** Elevation, slope, aspect, ecoregion, and soil type inform baseline vulnerability.
+
+## Deliverables
+
+- Harmonized raster archives ready for rapid metric extraction.
+- Pixel-level feature tables stored in `output/` for reuse in exploratory analyses.
+- BART model objects (`output/bart_model_fit.RData`) and variable importance reports.
+- Lead-time prediction rasters for visualization platforms or GIS overlays.
+
+## Roadmap
+
+- Expand the indicator suite with vegetation structure, phenology, and soil moisture anomalies.
+- Integrate explainable AI diagnostics to communicate uncertainty to field teams.
+- Publish interactive dashboards that pair predictions with management recommendations.
+
+## Get involved
+
+Interested in piloting the workflow in a new region or augmenting it with additional predictors? Open an issue on [GitHub](https://github.com/eco-trans/Eco_Trans_Early_Warning/issues) or connect via the [About page](../about/#connect).

--- a/docs/projects/fire-response-model-accuracy.md
+++ b/docs/projects/fire-response-model-accuracy.md
@@ -1,0 +1,36 @@
+---
+title: Fire-response model accuracy
+---
+
+# Fire-response model accuracy
+
+How do early warning indicators behave when forest transitions are driven by fire? This project examines model performance across disturbance regimes to ensure alerts remain trustworthy in dynamic, high-severity environments.
+
+## Objectives
+
+- Quantify the predictive power of early warning metrics for fire-related versus non-fire transitions.
+- Identify gaps where additional indicators or recalibrated models are required.
+- Provide actionable diagnostics for teams planning mitigation and recovery strategies.
+
+## Analytical approach
+
+1. **Labeling fire pathways:** [`scripts/model_accuracy_fire.R`](https://github.com/eco-trans/Eco_Trans_Early_Warning/blob/main/scripts/model_accuracy_fire.R) classifies pixels as fire-related when pre-transition fire frequency exceeds zero, using data assembled in `output/df_model_ready.csv`.
+2. **Generalized additive modeling:** `mgcv::gam` fits smooth relationships between autocorrelation, variance, NDVI slope, and transition likelihood.
+3. **Performance evaluation:** Stratified ROC curves generated with `pROC` reveal how accuracy differs between fire and non-fire contexts.
+
+!!! note "Key outputs"
+    The script prints overall AUC along with class-specific scores. These diagnostics guide whether to tune thresholds, add new predictors, or spin up custom models for fire-adapted landscapes.
+
+## Insights so far
+
+- Fire-driven transitions often exhibit sharper increases in variance and NDVI slope magnitude, requiring flexible smoothers to capture non-linear effects.
+- Non-fire transitions benefit from early detection of subtle autocorrelation shifts, highlighting the value of multi-metric monitoring.
+- Stratified reporting uncovers where intervention windows are shorter, informing resource allocation for prescribed burns or restoration.
+
+## Next steps
+
+- Extend the analysis with spatial cross-validation to assess regional generalizability.
+- Compare GAM results with tree-based classifiers to balance interpretability and raw predictive power.
+- Integrate forecast-ready visualizations that communicate confidence intervals to field partners.
+
+Interested in adapting the evaluation to your disturbance regime? Start with the documented script, then customize metrics or thresholds to suit your landscape.

--- a/docs/projects/index.md
+++ b/docs/projects/index.md
@@ -1,0 +1,54 @@
+---
+title: Projects
+---
+
+# Projects
+
+Explore a portfolio of research workflows designed to surface early warning signals and translate them into actionable insights. Each project pairs remote sensing data engineering with robust statistical modeling so stakeholders can move from awareness to intervention.
+
+<div class="project-grid">
+  <article class="project-card">
+    <h2>Eco-Trans Early Warning</h2>
+    <p>A flagship pipeline that ingests multi-decadal remote sensing archives, extracts early warning metrics, and maps lead times before ecosystem transitions occur.</p>
+    <ul class="project-meta">
+      <li><strong>Highlights:</strong> Automated raster alignment, signal emergence analytics, lead-time rasters</li>
+      <li><strong>Collaboration:</strong> Interdisciplinary team of ecologists, statisticians, and land managers</li>
+    </ul>
+    <div class="hero__actions">
+      <a class="md-button md-button--primary" href="eco-trans-early-warning/">Project overview</a>
+      <a class="md-button" href="https://github.com/eco-trans/Eco_Trans_Early_Warning" target="_blank" rel="noopener">Source code</a>
+    </div>
+  </article>
+  <article class="project-card">
+    <h2>Fire-response model accuracy</h2>
+    <p>Evaluates how early warning indicators behave across fire and non-fire pathways, revealing resilience thresholds and performance gaps.</p>
+    <ul class="project-meta">
+      <li><strong>Highlights:</strong> Stratified ROC evaluation, GAM-based diagnostics, actionable reporting</li>
+      <li><strong>Collaboration:</strong> Fire ecology partners seeking targeted mitigation strategies</li>
+    </ul>
+    <div class="hero__actions">
+      <a class="md-button md-button--primary" href="fire-response-model-accuracy/">Project overview</a>
+      <a class="md-button" href="https://github.com/eco-trans/Eco_Trans_Early_Warning" target="_blank" rel="noopener">Source code</a>
+    </div>
+  </article>
+  <article class="project-card">
+    <h2>Lead time prediction suite</h2>
+    <p>Combines Bayesian Additive Regression Trees with rich environmental predictors to quantify when interventions will be most effective.</p>
+    <ul class="project-meta">
+      <li><strong>Highlights:</strong> Predictor importance diagnostics, scenario-ready forecasts, interpretable outputs</li>
+      <li><strong>Collaboration:</strong> Resource planners balancing restoration investments</li>
+    </ul>
+    <div class="hero__actions">
+      <a class="md-button md-button--primary" href="lead-time-prediction-suite/">Project overview</a>
+      <a class="md-button" href="https://github.com/eco-trans/Eco_Trans_Early_Warning" target="_blank" rel="noopener">Source code</a>
+    </div>
+  </article>
+</div>
+
+## How to collaborate
+
+1. **Browse the project pages** to understand the data sources, modeling techniques, and current deliverables.
+2. **Open an issue or discussion** on GitHub to share project requirements or propose enhancements.
+3. **Co-develop extensions**—from new predictors to visualization components—using the documented workflows as a foundation.
+
+Ready to bring early warning analytics to your landscape? Let’s connect.

--- a/docs/projects/lead-time-prediction-suite.md
+++ b/docs/projects/lead-time-prediction-suite.md
@@ -1,0 +1,35 @@
+---
+title: Lead time prediction suite
+---
+
+# Lead time prediction suite
+
+A modeling toolkit that quantifies how long managers have to act before a transition completes. By pairing Bayesian Additive Regression Trees with interpretable summaries, the suite uncovers which environmental drivers most influence warning lead times.
+
+## Components
+
+- **Model training:** [`scripts/03_fit_bart_model.R`](https://github.com/eco-trans/Eco_Trans_Early_Warning/blob/main/scripts/03_fit_bart_model.R) ingests the engineered feature table, encodes categorical predictors, and fits a `dbarts` model with reproducible seeds.
+- **Scenario exploration:** Supplementary scripts such as [`scripts/bart_to_predict.R`](https://github.com/eco-trans/Eco_Trans_Early_Warning/blob/main/scripts/bart_to_predict.R) and [`scripts/prediction_sup2.R`](https://github.com/eco-trans/Eco_Trans_Early_Warning/blob/main/scripts/prediction_sup2.R) apply the trained model to new data, enabling what-if analyses.
+- **Spatial projection:** [`scripts/04_predict_lead_time_raster.R`](https://github.com/eco-trans/Eco_Trans_Early_Warning/blob/main/scripts/04_predict_lead_time_raster.R) converts predictions back to raster products for mapping and reporting.
+
+## Why BART?
+
+BART handles non-linear interactions and mixed data types while providing uncertainty-aware predictions. Variable inclusion counts expose which predictors—such as slope, soil type, or drought intensity—consistently drive lead-time changes.
+
+!!! tip "Interpreting outputs"
+    Inspect the saved `output/bart_model_fit.RData` object to explore partial dependence, variable importance, and posterior predictive intervals.
+
+## Deliverables
+
+- Clean modeling matrix with categorical encoding for soil type and ecoregion.
+- Serialized BART model suitable for reproducible deployment.
+- Lead-time rasters ready for ingestion into dashboards or GIS workflows.
+- Documentation for extending the model with new predictor sets.
+
+## Future enhancements
+
+- Integrate cross-validated hyperparameter tuning to balance accuracy and runtime.
+- Add interpretability notebooks highlighting spatial hotspots of short warning windows.
+- Package deployment scripts for cloud or batch processing environments.
+
+Use this suite when you need defensible, data-driven estimates of when ecological change will occur—and how to prioritize interventions before it does.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
-site_name: Forest Ecosystem Transformations Early Warning
+site_name: Nayani Ilangakoon | Remote Sensing Scientist
 site_author: Nayani Ilangakoon
 repo_url: https://github.com/eco-trans/Eco_Trans_Early_Warning
-site_description: Documentation for the Eco_Trans_Early_Warning remote sensing workflow.
+site_description: Research portfolio for remote sensing driven ecosystem early warning analytics.
 
 
 # Repository
@@ -9,16 +9,67 @@ repo_name: Eco_Trans_Early_Warning
 repo_url: https://github.com/eco-trans/Eco_Trans_Early_Warning
 edit_uri: edit/main/docs/
 # Copyright
-copyright: 'Copyright &copy; 2024 University of Colorado Boulder'
+copyright: 'Copyright &copy; 2024 Nayani Ilangakoon'
 
 
 
 theme:
   name: material
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - navigation.instant
+    - toc.integrate
+  palette:
+    - scheme: default
+      primary: teal
+      accent: light blue
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - scheme: slate
+      primary: teal
+      accent: light blue
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+  font:
+    text: "Inter"
+    code: "Fira Code"
+  icon:
+    logo: material/forest
 nav:
   - Home: index.md
+  - About: about.md
+  - Projects:
+      - Overview: projects/index.md
+      - Eco-Trans Early Warning: projects/eco-trans-early-warning.md
+      - Fire-Response Model Accuracy: projects/fire-response-model-accuracy.md
+      - Lead Time Prediction Suite: projects/lead-time-prediction-suite.md
   - Tutorials:
       - Workflow Overview: tutorials/workflow-overview.md
   - Reference:
       - Data & Output Structure: reference/data-structure.md
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/chathu84
+      name: GitHub
+extra_css:
+  - assets/styles/extra.css
+markdown_extensions:
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - pymdownx.details
+  - pymdownx.highlight
+  - pymdownx.inlinehilite
+  - pymdownx.superfences
+  - pymdownx.tabbed
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - tables
 docs_dir: docs


### PR DESCRIPTION
## Summary
- restyle the MkDocs configuration with a personal portfolio theme, navigation tabs, and social link
- redesign the home page with a hero section, feature highlights, and project cards that link to detailed pages
- add an about page, project hub, individual project write-ups, and supporting styles for a professional presentation

## Testing
- `mkdocs build` *(fails: mkdocs not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f8147f700483318c868613d5e9adf5